### PR TITLE
Fix README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Catalyst
 An Essentials plugin for Velocity!
 
-[![Discord](https://img.shields.io/discord/619325430431875072?style=for-the-badge)](https://discord.gg/6cXUEQJ)
+[![Discord](https://img.shields.io/discord/675484700357296138)](https://discord.gg/6gR2YH3) [![TeamCity Full Build Status](https://img.shields.io/teamcity/build/e/Catalyst_Build?server=http%3A%2F%2Fci.anvilpowered.org)](http://ci.anvilpowered.org/viewType.html?buildTypeId=Catalyst_Build&guest=1) [![GitHub](https://img.shields.io/github/license/AnvilPowered/Catalyst)](https://www.gnu.org/licenses/lgpl-3.0.html)
 
 # Status
 Please note, this plugin is still under heavy development, and is planned to be released ASAP.


### PR DESCRIPTION
The discord server badge is out of date. This PR updates it to the new discord server badge and adds a license and TeamCity build status badge.